### PR TITLE
Update deprecated actions/upload-artifact and actions/download-artifact dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           branch: ${{ github.head_ref }}
 
       - name: Upload build assets
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-assets
           path: dist
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download build assets
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-assets
 


### PR DESCRIPTION

# Purpose

This PR automatically updates actions that will stop working soon (see "when" section for more details):

- `actions/upload-artifact@v3`
- `actions/download-artifact@v3`


The PR could also include updates for these actions, that are deprecated since July:

- `actions/upload-artifact@v2`
- `actions/upload-artifact@v1`
- `actions/download-artifact@v2`
- `actions/download-artifact@v1`

## When

> Artifact actions v3 will be closing down by **December 5, 2024**. To raise awareness of the upcoming removal, we will temporarily fail jobs using v3 of actions/upload-artifact or actions/download-artifact. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
> - November 14, 12pm – 1pm EST
> - November 21, 9am – 5pm EST
>
> – [Notice of breaking changes for GitHub Actions](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/)

Please merge this PR as soon as possible to avoid broken CI pipelines on your services.

# IMPORTANT: Manual actions required

Please, review the migration guides and ensure that no change is needed. In most cases, you can merge this PR "as-is", but it's possible that some manual changes are required.

- [Migration guide for upload-artifact (v3 -> v4)](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)
- [Migration guide for download-artifact (v3 -> v4)](https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md)

If you're updating from versions older than v3, please see [download-artifact v3 README](https://github.com/actions/download-artifact/tree/v3/node20?tab=readme-ov-file#compatibility-between-v1-and-v2v3) for compatibility notes.

# Ticket

Feel free to use this ticket if you don't need to make further changes to this PR:

RAD-36957

# Notifications

(Please tag the appropiate codeowner / cc @fcano-ut)
